### PR TITLE
add buffer flag and add buffer for multiply kernel

### DIFF
--- a/paper/backend.py
+++ b/paper/backend.py
@@ -96,15 +96,15 @@ def multiply(A: PaperMatrix, B: PaperMatrix, output_path: str, buffer_manager: B
 
 # New parallel kernel
 
-def _process_fused_tile(A_data, B_data, scalar, r_start, r_end, c_start, c_end, buffer_manager: BufferManager):
+def _process_fused_tile(A, B, scalar, r_start, r_end, c_start, c_end, buffer_manager: BufferManager):
     """Helper function to process a single tile. This is what each thread runs."""
     
     if buffer_manager:
-        tile_A = buffer_manager.get_tile(A_data, r_start, c_start)
-        tile_B = buffer_manager.get_tile(B_data, r_start, c_start)
+        tile_A = buffer_manager.get_tile(A, r_start, c_start)
+        tile_B = buffer_manager.get_tile(B, r_start, c_start)
     else:
-        tile_A = A_data[r_start:r_end, c_start:c_end]
-        tile_B = B_data[r_start:r_end, c_start:c_end]
+        tile_A = A.data[r_start:r_end, c_start:c_end]
+        tile_B = B.data[r_start:r_end, c_start:c_end]
 
     fused_result_tile = (tile_A + tile_B) * scalar
     return r_start, c_start, fused_result_tile

--- a/paper/plan.py
+++ b/paper/plan.py
@@ -8,7 +8,7 @@ from .backend import execute_fused_add_multiply
 
 from .buffer import BufferManager
 
-use_buffer_manager = True  # Set to False to disable buffer manager
+use_buffer_manager = False  # Set to False to disable buffer manager
 
 class Plan:
     """Represents a computation that will result in a matrix, but is not yet executed."""


### PR DESCRIPTION

Issues

```
File "/usr/local/python/3.12.1/lib/python3.12/concurrent/futures/_base.py", line 449, in result
    return self.__get_result()
           ^^^^^^^^^^^^^^^^^^^
  File "/usr/local/python/3.12.1/lib/python3.12/concurrent/futures/_base.py", line 401, in __get_result
    raise self._exception
  File "/usr/local/python/3.12.1/lib/python3.12/concurrent/futures/thread.py", line 58, in run
    result = self.fn(*self.args, **self.kwargs)
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/workspaces/ooc/paper/backend.py", line 103, in _process_fused_tile
    tile_A = buffer_manager.get_tile(A_data, r_start, c_start)
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/workspaces/ooc/paper/buffer.py", line 24, in get_tile
    tile_key = (matrix.filepath, r_start, c_start)
                ^^^^^^^^^^^^^^^
AttributeError: 'memmap' object has no attribute 'filepath'. Did you mean: 'filename'?
```

to fix this, we need to update the 

```py
with ThreadPoolExecutor(max_workers=4) as executor:
        futures = []
        # Submit all tile-processing tasks to the thread pool.
        for r_start in range(0, rows, TILE_SIZE):
            r_end = min(r_start + TILE_SIZE, rows)
            for c_start in range(0, cols, TILE_SIZE):
                c_end = min(c_start + TILE_SIZE, cols)
                # submit() schedules the function to run and returns a Future object.
                future = executor.submit(
                    _process_fused_tile,
                    A.data, B.data, scalar,
                    r_start, r_end, c_start, c_end
                )
                futures.append(future)
```